### PR TITLE
Fixed typo in Scale9Image where width distortion scale is measured

### DIFF
--- a/source/feathers/display/Scale9Image.as
+++ b/source/feathers/display/Scale9Image.as
@@ -510,7 +510,7 @@ package feathers.display
 					var distortionScale:Number = (this._width / sumLeftAndRight);
 					scaledLeftWidth *= distortionScale;
 					scaledRightWidth *= distortionScale;
-					sumLeftAndRight + scaledLeftWidth + scaledRightWidth;
+					sumLeftAndRight = scaledLeftWidth + scaledRightWidth;
 				}
 				var scaledCenterWidth:Number = this._width - sumLeftAndRight;
 				var scaledTopHeight:Number = grid.y * this._textureScale;


### PR DESCRIPTION
Something small I noticed when I updated our project to start using feathers 2.1.0 from an older version.