### PR TITLE
Starling 1.6 compatibility for v1.3.x, branch to v1.4.x required

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Feathers 1.3.1
+# Feathers 1.4.1
 
 Say hello to [Feathers](http://feathersui.com/), a library of light-weight, skinnable, and extensible UI controls for mobile and desktop. The components run on [Starling Framework](http://starling-framework.org/) and the [Adobe Flash runtimes](http://gaming.adobe.com/technologies/) — offering blazing fast GPU powered graphics to create a smooth and responsive experience. Build completely standalone, native applications on iOS, Android, Windows, and Mac OS X, or target Adobe Flash Player in desktop browsers. Created by [Josh Tynjala](http://twitter.com/joshtynjala), Feathers is free and open source.
 
@@ -16,7 +16,7 @@ Say hello to [Feathers](http://feathersui.com/), a library of light-weight, skin
 ## Minimum Requirements
 
 * Adobe AIR 3.5 or Adobe Flash Player 11.5
-* Starling Framework 1.4.1
+* Starling Framework 1.6
 
 ## Downloads
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Feathers 1.4.1
+# Feathers 1.4.0
 
 Say hello to [Feathers](http://feathersui.com/), a library of light-weight, skinnable, and extensible UI controls for mobile and desktop. The components run on [Starling Framework](http://starling-framework.org/) and the [Adobe Flash runtimes](http://gaming.adobe.com/technologies/) — offering blazing fast GPU powered graphics to create a smooth and responsive experience. Build completely standalone, native applications on iOS, Android, Windows, and Mac OS X, or target Adobe Flash Player in desktop browsers. Created by [Josh Tynjala](http://twitter.com/joshtynjala), Feathers is free and open source.
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,9 @@
 
 Noteworthy changes in official, stable releases of [Feathers](http://feathersui.com/).
 
+## 1.4.0
+* Scale4Image, Scale9Image, TiledImage: updated overridden flatten method to compile with starling 1.6
+
 ## 1.3.1
 
 * NumericStepper: fixed issue where using step to calculate a new value didn't account for the minimum value.

--- a/build.properties
+++ b/build.properties
@@ -16,6 +16,6 @@ swf.version = 18
 
 mxml.namespace = library://ns.feathersui.com/mxml
 
-feathers.version = 1.3.1
+feathers.version = 1.4.0
 
 footer.text = <a href='http://feathersui.com/' target='_top'>Feathers Website</a> | <a href='http://wiki.starling-framework.org/feathers/start' target='_top'>Feathers Documentation</a> | <a href='https://github.com/joshtynjala/feathers' target='_top'>Github Project</a> | <a href='http://forum.starling-framework.org/forum/feathers' target='_top'>Support Forum</a>

--- a/source/feathers/display/Scale3Image.as
+++ b/source/feathers/display/Scale3Image.as
@@ -435,10 +435,10 @@ package feathers.display
 		/**
 		 * @private
 		 */
-		override public function flatten():void
+		override public function flatten(ignoreChildOrder:Boolean = false):void
 		{
 			this.validate();
-			super.flatten();
+			super.flatten(ignoreChildOrder);
 		}
 
 		/**

--- a/source/feathers/display/Scale9Image.as
+++ b/source/feathers/display/Scale9Image.as
@@ -435,10 +435,10 @@ package feathers.display
 		/**
 		 * @private
 		 */
-		override public function flatten():void
+		override public function flatten(ignoreChildOrder:Boolean = false):void
 		{
 			this.validate();
-			super.flatten();
+			super.flatten(ignoreChildOrder);
 		}
 
 		/**

--- a/source/feathers/display/TiledImage.as
+++ b/source/feathers/display/TiledImage.as
@@ -432,10 +432,10 @@ package feathers.display
 		/**
 		 * @private
 		 */
-		override public function flatten():void
+		override public function flatten(ignoreChildOrder:Boolean = false):void
 		{
 			this.validate();
-			super.flatten();
+			super.flatten(ignoreChildOrder);
 		}
 
 		/**


### PR DESCRIPTION
Version 1.3.x is not compatible with Starling 1.6 because few methods signature changed.
It's a minor change but this fix would allow old code based on 1.3.x versions to run with the latest version of Starling.

I suggest to create a v1.4.x in the main project.
