### PR TITLE
Fix for text area background skins not updating.

### DIFF
--- a/source/feathers/controls/TextArea.as
+++ b/source/feathers/controls/TextArea.as
@@ -939,7 +939,7 @@ package feathers.controls
 			{
 				this.currentBackgroundSkin = this._backgroundDisabledSkin;
 			}
-			else if(this._hasFocus && this._backgroundFocusedSkin)
+			else if(this.hasFocus && this._backgroundFocusedSkin)
 			{
 				this.currentBackgroundSkin = this._backgroundFocusedSkin;
 			}


### PR DESCRIPTION
I encountered this bug by using a text field without a focus manager and upon gaining focus to the text, the background skin remained to the default (non-focused) one. 

It seems to be related to the difference between `this._hasFocus` and the the getter `this.hasFocus`. In my situation `this._hasFocus = false`, while `this.hasFocus = true` because `this._focusManager = null` and  `this._textEditorHasFocus = true`. 

I think `refreshBackgroundSkin()` should check `this.hasFocus` in order to switch to the focused skin properly in my situation.